### PR TITLE
Improve manifest formatting

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,11 @@
     }
   },
   "background": {
-     "scripts": ["snapdrop/network.js","snapdrop/connect.js","background.js"]
+     "scripts": [
+       "snapdrop/network.js",
+       "snapdrop/connect.js",
+       "background.js"
+     ]
   },
   "icons": {
     "128": "sd.png"


### PR DESCRIPTION
I noticed an inline array in the manifest. The other arrays are multi-line. Now, they will be uniform.